### PR TITLE
Add unit tests for controllers and routes

### DIFF
--- a/tests/lockController.test.js
+++ b/tests/lockController.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('module');
+
+function createRes() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return { json: payload => { this.body = payload; } };
+    },
+    json(payload) { this.body = payload; }
+  };
+}
+
+const originalRequire = Module.prototype.require;
+
+function withStubs(stubs, fn) {
+  Module.prototype.require = function(path) {
+    if (path in stubs) return stubs[path];
+    return originalRequire.apply(this, arguments);
+  };
+  delete require.cache[require.resolve('../controllers/lockController')];
+  try { return fn(); } finally { Module.prototype.require = originalRequire; }
+}
+
+test('openLock denies access when hasAccessToLock is false', async () => {
+  await withStubs({
+    '../utils/accessControl': {
+      hasAccessToLock: async () => false,
+      logAccess: async () => {}
+    },
+    '../config/db': { query: async () => [] },
+    '../adapters/raspberryAdapter': {},
+    '../adapters/aviorAdapter': {}
+  }, async () => {
+    const { openLock } = require('../controllers/lockController');
+    const req = { params: { id: 1 }, user: { id: 10 } };
+    const res = createRes();
+    await openLock(req, res);
+    assert.strictEqual(res.statusCode, 403);
+    assert.deepStrictEqual(res.body, { error: 'Ingen tilgang til denne låsen' });
+  });
+});
+
+test('lockLock denies access when hasAccessToLock is false', async () => {
+  await withStubs({
+    '../utils/accessControl': {
+      hasAccessToLock: async () => false,
+      logAccess: async () => {}
+    },
+    '../config/db': { query: async () => [] },
+    '../adapters/raspberryAdapter': {},
+    '../adapters/aviorAdapter': {}
+  }, async () => {
+    const { lockLock } = require('../controllers/lockController');
+    const req = { params: { id: 1 }, user: { id: 10 } };
+    const res = createRes();
+    await lockLock(req, res);
+    assert.strictEqual(res.statusCode, 403);
+    assert.deepStrictEqual(res.body, { error: 'Ingen tilgang til denne låsen' });
+  });
+});

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const Module = require('module');
+
+const originalRequire = Module.prototype.require;
+function withStubs(stubs, fn) {
+  Module.prototype.require = function(path) {
+    if (path in stubs) return stubs[path];
+    return originalRequire.apply(this, arguments);
+  };
+  for (const mod of [
+    '../controllers/userController',
+    '../controllers/lockController',
+    '../routes/userRoutes',
+    '../routes/lockRoutes'
+  ]) {
+    delete require.cache[require.resolve(mod)];
+  }
+  try { return fn(); } finally { Module.prototype.require = originalRequire; }
+}
+
+function findRoute(router, path, method) {
+  return router.stack.find(l => l.route && l.route.path === path && l.route.methods[method]);
+}
+
+test('userRoutes exposes POST /login', () => {
+  withStubs({
+    '../adapters/raspberryAdapter': {},
+    '../adapters/aviorAdapter': {}
+  }, () => {
+    const userRoutes = require('../routes/userRoutes');
+    const userController = require('../controllers/userController');
+    const layer = findRoute(userRoutes, '/login', 'post');
+    assert.ok(layer);
+    assert.strictEqual(layer.route.stack[0].handle, userController.loginUser);
+  });
+});
+
+test('lockRoutes exposes POST /:id/open', () => {
+  withStubs({
+    '../adapters/raspberryAdapter': {},
+    '../adapters/aviorAdapter': {}
+  }, () => {
+    const lockRoutes = require('../routes/lockRoutes');
+    const lockController = require('../controllers/lockController');
+    const layer = findRoute(lockRoutes, '/:id/open', 'post');
+    assert.ok(layer);
+    const handlers = layer.route.stack.map(s => s.handle);
+    assert.ok(handlers.includes(lockController.openLock));
+  });
+});
+
+test('lockRoutes exposes POST /:id/lock', () => {
+  withStubs({
+    '../adapters/raspberryAdapter': {},
+    '../adapters/aviorAdapter': {}
+  }, () => {
+    const lockRoutes = require('../routes/lockRoutes');
+    const lockController = require('../controllers/lockController');
+    const layer = findRoute(lockRoutes, '/:id/lock', 'post');
+    assert.ok(layer);
+    const handlers = layer.route.stack.map(s => s.handle);
+    assert.ok(handlers.includes(lockController.lockLock));
+  });
+});

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('module');
+
+function createRes() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return {
+        json: payload => {
+          this.body = payload;
+        }
+      };
+    },
+    json(payload) {
+      this.body = payload;
+    }
+  };
+}
+
+const originalRequire = Module.prototype.require;
+
+function withStubs(stubs, fn) {
+  Module.prototype.require = function (path) {
+    if (path in stubs) return stubs[path];
+    return originalRequire.apply(this, arguments);
+  };
+  const toClear = ['../controllers/userController'];
+  for (const m of toClear) {
+    delete require.cache[require.resolve(m)];
+  }
+  try {
+    return fn();
+  } finally {
+    Module.prototype.require = originalRequire;
+  }
+}
+
+// Test successful login
+
+test('loginUser returns token on valid credentials', async () => {
+  await withStubs({
+    '../config/db': { query: async () => [{ id: 1, email: 'e', password: 'h', role: 'user' }] },
+    'bcryptjs': { compare: async () => true },
+    'jsonwebtoken': { sign: () => 'signed' }
+  }, async () => {
+    const { loginUser } = require('../controllers/userController');
+    const req = { body: { email: 'e', password: 'p' } };
+    const res = createRes();
+    await loginUser(req, res);
+    assert.deepStrictEqual(res.body, { token: 'signed' });
+    assert.strictEqual(res.statusCode, undefined);
+  });
+});
+
+// Test invalid password
+
+test('loginUser rejects invalid password', async () => {
+  await withStubs({
+    '../config/db': { query: async () => [{ id: 1, email: 'e', password: 'h', role: 'user' }] },
+    'bcryptjs': { compare: async () => false },
+    'jsonwebtoken': { sign: () => 'signed' }
+  }, async () => {
+    const { loginUser } = require('../controllers/userController');
+    const req = { body: { email: 'e', password: 'wrong' } };
+    const res = createRes();
+    await loginUser(req, res);
+    assert.strictEqual(res.statusCode, 401);
+    assert.deepStrictEqual(res.body, { error: 'Ugyldig e-post eller passord' });
+  });
+});


### PR DESCRIPTION
## Summary
- add login controller tests
- add lock controller tests for open/lock access failures
- verify route registration for login and lock operations

## Testing
- `npm test`