### PR TITLE
Fix accessGroupController start error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ DB_NAME=kf_flow
 JWT_SECRET=your_jwt_secret
 PI_API_KEY=my_pi_internal_key
 ```
-=======
 
 Dette er en Node.js-basert server for prototyping av adgangssystemet *Keyfree Flow*.
 
@@ -64,7 +63,6 @@ curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/me
 
 Swagger-dokumentasjon er tilgjengelig på `http://localhost:3000/api-docs` etter at serveren er startet.
 
-=======
 Denne applikasjonen bruker Node.js. Prosjektet inkluderer enkle enhetstester som kan kjøres med Node sitt innebygde test-rammeverk.
 
 ## Kjøre tester

--- a/controllers/accessGroupController.js
+++ b/controllers/accessGroupController.js
@@ -1,7 +1,5 @@
-
 const logger = require('../utils/logger');
 logger.debug('>>> accessGroupController loaded');
-=======
 console.log('>>> FILEN LASTER INN');
 const jwt = require('jsonwebtoken');
 


### PR DESCRIPTION
## Summary
- remove stray conflict markers in `accessGroupController`
- clean up README artifacts

## Testing
- `npm test`
- `node app.js` (fails initially due to missing env var; after adding env var locally, server starts)