### PR TITLE
Improve Swagger docs with response schemas

### DIFF
--- a/routes/accessGroupRoutes.js
+++ b/routes/accessGroupRoutes.js
@@ -28,6 +28,23 @@ logger.debug('requireAdmin:', typeof requireAdmin);
  *     responses:
  *       200:
  *         description: Liste over tilgangsgrupper
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   name:
+ *                     type: string
+ *                   role:
+ *                     type: string
+ *                   user_count:
+ *                     type: integer
+ *                   lock_count:
+ *                     type: integer
  *       401:
  *         description: Ugyldig eller manglende token
  *       500:
@@ -56,6 +73,19 @@ router.post('/list', verifyToken, accessGroupController.getAccessGroupsForUser);
  *     responses:
  *       200:
  *         description: Liste over brukere i gruppen
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   email:
+ *                     type: string
+ *                   role:
+ *                     type: string
  *       401:
  *         description: Ugyldig eller manglende token
  *       403:

--- a/routes/lockRoutes.js
+++ b/routes/lockRoutes.js
@@ -32,6 +32,15 @@ const lockController = require('../controllers/lockController');
  *     responses:
  *       200:
  *         description: Låsen ble opprettet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 id:
+ *                   type: integer
  *       400:
  *         description: Ugyldig input
  *       500:
@@ -51,6 +60,47 @@ router.post('/', verifyToken, lockController.createLock);
  *     responses:
  *       200:
  *         description: Liste over låser
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user_id:
+ *                   type: integer
+ *                 locks:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                       name:
+ *                         type: string
+ *                       type:
+ *                         type: string
+ *                       eier:
+ *                         type: string
+ *                       floor:
+ *                         type: string
+ *                       room:
+ *                         type: string
+ *                       adress:
+ *                         type: string
+ *                       adapter_data:
+ *                         type: object
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   name:
+ *                     type: string
+ *                   status:
+ *                     type: string
  *       500:
  *         description: Feil ved henting av låser
  */
@@ -76,6 +126,15 @@ router.get('/', verifyToken, lockController.getAccessibleLocks);
  *     responses:
  *       200:
  *         description: Statusinformasjon
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 status:
+ *                   type: string
  *       403:
  *         description: Ingen tilgang
  *       500:
@@ -101,6 +160,15 @@ router.get('/:id/status', verifyToken, lockController.lockStatus);
  *     responses:
  *       200:
  *         description: Låsen åpnet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 result:
+ *                   type: string
  *       403:
  *         description: Ingen tilgang
  *       500:
@@ -127,6 +195,15 @@ router.post('/:id/open', verifyToken, lockController.openLock);
  *     responses:
  *       200:
  *         description: Låsen låst
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 result:
+ *                   type: string
  *       403:
  *         description: Ingen tilgang
  *       500:
@@ -154,6 +231,29 @@ router.post('/:id/lock', verifyToken, lockController.lockLock);
  *     responses:
  *       200:
  *         description: Låser til bruker
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   name:
+ *                     type: string
+ *                   type:
+ *                     type: string
+ *                   eier:
+ *                     type: string
+ *                   floor:
+ *                     type: string
+ *                   room:
+ *                     type: string
+ *                   adress:
+ *                     type: string
+ *                   adapter_data:
+ *                     type: object
  */
 router.post('/accessible', verifyToken, lockController.getLockList);
 /**
@@ -178,6 +278,29 @@ router.post('/accessible', verifyToken, lockController.getLockList);
  *     responses:
  *       200:
  *         description: Låsdetaljer
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                 name:
+ *                   type: string
+ *                 type:
+ *                   type: string
+ *                 eier:
+ *                   type: string
+ *                 floor:
+ *                   type: string
+ *                 room:
+ *                   type: string
+ *                 adress:
+ *                   type: string
+ *                 adapter_data:
+ *                   type: object
+ *                 status:
+ *                   type: string
  *       404:
  *         description: Ikke funnet
  *       500:
@@ -226,6 +349,19 @@ router.post('/all_accessible', verifyToken, lockController.getAllAccessibleLocks
  *     responses:
  *       200:
  *         description: Liste over brukere med tilgang
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   email:
+ *                     type: string
+ *                   role:
+ *                     type: string
  *       403:
  *         description: Ingen tilgang
  *       500:

--- a/routes/logRoutes.js
+++ b/routes/logRoutes.js
@@ -23,6 +23,31 @@ router.use(verifyToken);
  *     responses:
  *       200:
  *         description: Liste over logger
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   user_id:
+ *                     type: integer
+ *                   lock_id:
+ *                     type: integer
+ *                   action:
+ *                     type: string
+ *                   result:
+ *                     type: string
+ *                   success:
+ *                     type: boolean
+ *                   timestamp:
+ *                     type: string
+ *                   username:
+ *                     type: string
+ *                   lock_name:
+ *                     type: string
  *       500:
  *         description: Kunne ikke hente logger
  */
@@ -47,12 +72,74 @@ router.get('/', logController.getAllLogs);
  *     responses:
  *       200:
  *         description: Logger for valgt lås
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   user_id:
+ *                     type: integer
+ *                   lock_id:
+ *                     type: integer
+ *                   action:
+ *                     type: string
+ *                   result:
+ *                     type: string
+ *                   success:
+ *                     type: boolean
+ *                   timestamp:
+ *                     type: string
+ *                   formatted_date:
+ *                     type: string
+ *                   formatted_time:
+ *                     type: string
+ *                   username:
+ *                     type: string
  *       500:
  *         description: Kunne ikke hente logger
  */
 
 router.get('/:lockId', verifyToken, logController.getLogsByLock);
 
+/**
+ * @swagger
+ * /log/{lockId}/last:
+ *   get:
+ *     summary: Hent siste aktivitet for en lås
+ *     tags:
+ *       - Logger
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: lockId
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: ID for låsen
+ *     responses:
+ *       200:
+ *         description: Siste aktivitet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 last_action:
+ *                   type: string
+ *                 timestamp:
+ *                   type: string
+ *                 formatted_date:
+ *                   type: string
+ *                 formatted_time:
+ *                   type: string
+ *                 username:
+ *                   type: string
+ */
 router.get('/:lockId/last', verifyToken, getLastActivityForLock);
 
 module.exports = router;

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -16,6 +16,28 @@ const { verifyToken } = require('../middleware/authMiddleware');
  *     responses:
  *       200:
  *         description: Brukerprofil
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                     first_name:
+ *                       type: string
+ *                     last_name:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     phone_number:
+ *                       type: string
+ *                     role:
+ *                       type: string
+ *                     created_at:
+ *                       type: string
  *       404:
  *         description: Bruker ikke funnet
  *       500:

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -24,6 +24,13 @@ const userlocksController = require('../controllers/userlocksController')
  *     responses:
  *       200:
  *         description: Returnerer en JWT-token ved suksess
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
  *       401:
  *         description: Ugyldig e-post eller passord
  */
@@ -47,6 +54,19 @@ router.post('/login', userController.loginUser);
  *     responses:
  *       200:
  *         description: Liste over brukere
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   email:
+ *                     type: string
+ *                   role:
+ *                     type: string
+ *                   lock_count:
+ *                     type: integer
  *       400:
  *         description: Mangler nødvendig data
  */


### PR DESCRIPTION
## Summary
- document API responses for lock routes
- document API responses for user, profile, log and access group routes
- add Swagger docs for `/log/{lockId}/last`

## Testing
- `npm test`