### PR TITLE
Add simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/me
 ```
 
 Swagger-dokumentasjon er tilgjengelig på `http://localhost:3000/api-docs` etter at serveren er startet.
+Et enkelt web-grensesnitt ligger i `public/webui/index.html`. Start serveren og åpne `http://localhost:3000/webui/index.html` i nettleseren for å logge inn, se og opprette låser samt administrere tilgangsgrupper.
+
 
 Denne applikasjonen bruker Node.js. Prosjektet inkluderer enkle enhetstester som kan kjøres med Node sitt innebygde test-rammeverk.
 

--- a/public/webui/app.js
+++ b/public/webui/app.js
@@ -1,0 +1,124 @@
+let token = localStorage.getItem('token');
+const loginSection = document.getElementById('loginSection');
+const dashboard = document.getElementById('dashboard');
+const loginError = document.getElementById('loginError');
+
+function showDashboard() {
+  loginSection.classList.add('hidden');
+  dashboard.classList.remove('hidden');
+  loadLocks();
+  loadGroups();
+}
+
+function showLogin() {
+  dashboard.classList.add('hidden');
+  loginSection.classList.remove('hidden');
+}
+
+if (token) {
+  showDashboard();
+}
+
+// Login form
+const loginForm = document.getElementById('loginForm');
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('/user/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    token = data.token;
+    localStorage.setItem('token', token);
+    showDashboard();
+  } else {
+    loginError.textContent = 'Innlogging feilet';
+  }
+});
+
+// Load locks
+async function loadLocks() {
+  const res = await fetch('/lock', {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  const list = document.getElementById('lockList');
+  list.innerHTML = '';
+  if (res.ok) {
+    const locks = await res.json();
+    for (const lock of locks) {
+      const li = document.createElement('li');
+      li.textContent = `${lock.id}: ${lock.name} (${lock.status})`;
+      list.appendChild(li);
+    }
+  } else {
+    list.textContent = 'Kunne ikke hente låser';
+  }
+}
+
+document.getElementById('refreshLocks').onclick = loadLocks;
+
+// Create lock
+const createLockForm = document.getElementById('createLockForm');
+createLockForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('lockName').value;
+  const type = document.getElementById('lockType').value;
+  let adapterData;
+  try { adapterData = JSON.parse(document.getElementById('adapterData').value); } catch { adapterData = {}; }
+  const res = await fetch('/lock', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify({ name, type, adapter_data: adapterData })
+  });
+  if (res.ok) {
+    alert('Lås opprettet');
+    loadLocks();
+  } else {
+    alert('Feil ved opprettelse av lås');
+  }
+});
+
+// Load groups
+async function loadGroups() {
+  const res = await fetch('/accessgroup/list', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify({ token })
+  });
+  const list = document.getElementById('groupList');
+  list.innerHTML = '';
+  if (res.ok) {
+    const groups = await res.json();
+    for (const g of groups) {
+      const li = document.createElement('li');
+      li.textContent = `${g.id}: ${g.name} (${g.role})`;
+      list.appendChild(li);
+    }
+  } else {
+    list.textContent = 'Kunne ikke hente grupper';
+  }
+}
+
+document.getElementById('refreshGroups').onclick = loadGroups;
+
+// Create group
+const createGroupForm = document.getElementById('createGroupForm');
+createGroupForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('groupName').value;
+  const res = await fetch('/accessgroup/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify({ name })
+  });
+  if (res.ok) {
+    alert('Gruppe opprettet');
+    loadGroups();
+  } else {
+    alert('Feil ved opprettelse av gruppe');
+  }
+});

--- a/public/webui/index.html
+++ b/public/webui/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keyfree Flow UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; }
+    .hidden { display: none; }
+    form { margin-bottom: 1em; }
+    label { display: block; margin: 0.2em 0; }
+  </style>
+</head>
+<body>
+  <h1>Keyfree Flow</h1>
+  <div id="loginSection">
+    <h2>Logg inn</h2>
+    <form id="loginForm">
+      <label>E‑post: <input type="email" id="email"></label>
+      <label>Passord: <input type="password" id="password"></label>
+      <button type="submit">Logg inn</button>
+    </form>
+    <pre id="loginError" style="color:red"></pre>
+  </div>
+
+  <div id="dashboard" class="hidden">
+    <h2>Mine låser</h2>
+    <button id="refreshLocks">Oppdater</button>
+    <ul id="lockList"></ul>
+
+    <h3>Opprett ny lås</h3>
+    <form id="createLockForm">
+      <label>Navn: <input type="text" id="lockName"></label>
+      <label>Type:
+        <select id="lockType">
+          <option value="raspberry">raspberry</option>
+          <option value="avior">avior</option>
+        </select>
+      </label>
+      <label>Adapter-data (JSON): <input type="text" id="adapterData" value='{"ip":"","pin":0}'></label>
+      <button type="submit">Opprett</button>
+    </form>
+
+    <h3>Tilgangsgrupper</h3>
+    <button id="refreshGroups">Oppdater grupper</button>
+    <ul id="groupList"></ul>
+    <h4>Opprett gruppe</h4>
+    <form id="createGroupForm">
+      <label>Navn: <input type="text" id="groupName"></label>
+      <button type="submit">Opprett gruppe</button>
+    </form>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/routes/accessGroupRoutes.js
+++ b/routes/accessGroupRoutes.js
@@ -51,6 +51,15 @@ logger.debug('requireAdmin:', typeof requireAdmin);
  *         description: Serverfeil
  */
 router.post('/list', verifyToken, accessGroupController.getAccessGroupsForUser);
+
+// Opprett ny tilgangsgruppe
+router.post('/create', verifyToken, accessGroupController.createGroup);
+
+// Legg til bruker i gruppe
+router.post('/add-user', verifyToken, accessGroupController.addUserToGroup);
+
+// Legg til lås i gruppe
+router.post('/add-lock', verifyToken, accessGroupController.addLockToGroup);
 /**
  * @swagger
  * /accessgroup/users:


### PR DESCRIPTION
## Summary
- add `/public/webui` with a small client-side app for login and lock management
- expose new endpoints in `accessGroupRoutes` for managing groups
- mention the UI in the README

## Testing
- `npm test`