### PR TITLE
Add API overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,59 @@ curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/me
 Swagger-dokumentasjon er tilgjengelig på `http://localhost:3000/api-docs` etter at serveren er startet.
 Et enkelt web-grensesnitt ligger i `public/webui/index.html`. Start serveren og åpne `http://localhost:3000/webui/index.html` i nettleseren for å logge inn, se og opprette låser samt administrere tilgangsgrupper.
 
+## API-endepunkter
+
+Nedenfor følger en kort oversikt over de viktigste API-kallene. De fleste krever at du sender med en gyldig JWT-token i `Authorization`-headeren ("Bearer `<TOKEN>`").
+
+### Autentisering og generelle
+
+| Metode | URL | Beskrivelse |
+| ------ | --- | ----------- |
+| `POST` | `/auth/register` | Opprett en ny bruker |
+| `POST` | `/auth/login` | Logg inn og motta JWT |
+| `GET` | `/me` | Eksempel på beskyttet rute |
+| `GET` | `/health` | Helsetest av serveren |
+
+### Brukerrelaterte
+
+| Metode | URL | Beskrivelse |
+| ------ | --- | ----------- |
+| `POST` | `/user/login` | Autentiser bruker (alternativ innlogging) |
+| `POST` | `/user/userlocks/shared-users` | Liste over brukere en lås er delt med |
+
+### Låser
+
+| Metode | URL | Beskrivelse |
+| ------ | --- | ----------- |
+| `POST` | `/lock` | Opprett ny lås |
+| `GET` | `/lock` | Hent låser brukeren har tilgang til |
+| `GET` | `/lock/:id/status` | Hent status for gitt lås |
+| `POST` | `/lock/:id/open` | Åpne lås |
+| `POST` | `/lock/:id/lock` | Lås lås |
+| `POST` | `/lock/accessible` | Låser som eies av innlogget bruker |
+| `POST` | `/lock/getbyid` | Hent detaljer for en lås via ID |
+| `POST` | `/lock/all_accessible` | Alle låser brukeren kan åpne |
+| `GET` | `/lock/:id/users` | Brukere med tilgang til en lås |
+
+### Tilgangsgrupper
+
+| Metode | URL | Beskrivelse |
+| ------ | --- | ----------- |
+| `POST` | `/accessgroup/list` | Tilgangsgrupper knyttet til innlogget bruker |
+| `POST` | `/accessgroup/create` | Opprett ny tilgangsgruppe |
+| `POST` | `/accessgroup/add-user` | Legg til bruker i gruppe |
+| `POST` | `/accessgroup/add-lock` | Legg til lås i gruppe |
+| `POST` | `/accessgroup/users` | Hent brukere i en tilgangsgruppe |
+
+### Logger og profiler
+
+| Metode | URL | Beskrivelse |
+| ------ | --- | ----------- |
+| `GET` | `/log` | Hent alle adgangslogger |
+| `GET` | `/log/:lockId` | Logger for en spesifikk lås |
+| `GET` | `/log/:lockId/last` | Siste aktivitet på lås |
+| `POST` | `/profile/profile` | Profilinformasjon for innlogget bruker |
+
 
 Denne applikasjonen bruker Node.js. Prosjektet inkluderer enkle enhetstester som kan kjøres med Node sitt innebygde test-rammeverk.
 


### PR DESCRIPTION
## Summary
- document API endpoints in README for easy reference

## Testing
- `npm test` *(fails: Cannot find module 'jsonwebtoken')*